### PR TITLE
issue #46: Fix rowId issue when pushdown of projections or aggregation

### DIFF
--- a/src/main/scala/com/qubole/spark/hiveacid/hive/HiveAcidMetadata.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/hive/HiveAcidMetadata.scala
@@ -84,18 +84,6 @@ class HiveAcidMetadata(sparkSession: SparkSession,
   val partitionSchema = StructType(hTable.getPartitionKeys.toList.map(
     HiveConverter.getCatalystStructField).toArray)
 
-  val rowIdSchema: StructType = {
-    StructType(
-      RecordIdentifier.Field.values().map {
-        field =>
-          StructField(
-            name = field.name(),
-            dataType = HiveConverter.getCatalystType(field.fieldType.getTypeName),
-            nullable = true)
-      }
-    )
-  }
-
   val tableSchema: StructType = {
     val overlappedPartCols = mutable.Map.empty[String, StructField]
     partitionSchema.foreach { partitionField =>
@@ -110,7 +98,7 @@ class HiveAcidMetadata(sparkSession: SparkSession,
   val tableSchemaWithRowId: StructType = {
     StructType(
       Seq(
-        StructField("rowId", rowIdSchema)
+        StructField(HiveAcidMetadata.rowIdCol, HiveAcidMetadata.rowIdSchema)
       ) ++ tableSchema.fields)
   }
 
@@ -154,6 +142,19 @@ class HiveAcidMetadata(sparkSession: SparkSession,
 
 object HiveAcidMetadata {
   val DEFAULT_DATABASE = "default"
+
+  val rowIdCol = "rowId"
+  val rowIdSchema: StructType = {
+    StructType(
+      RecordIdentifier.Field.values().map {
+        field =>
+          StructField(
+            name = field.name(),
+            dataType = HiveConverter.getCatalystType(field.fieldType.getTypeName),
+            nullable = true)
+      }
+    )
+  }
 
   def fromSparkSession(sparkSession: SparkSession,
                        fullyQualifiedTableName: String): HiveAcidMetadata = {

--- a/src/main/scala/com/qubole/spark/hiveacid/reader/TableReader.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/reader/TableReader.scala
@@ -44,7 +44,7 @@ private[hiveacid] class TableReader(sparkSession: SparkSession,
   def getRdd(requiredColumns: Array[String],
              filters: Array[Filter],
              readConf: SparkAcidConf): RDD[Row] = {
-    val rowIdColumnSet = hiveAcidMetadata.rowIdSchema.fields.map(_.name).toSet
+    val rowIdColumnSet = HiveAcidMetadata.rowIdSchema.fields.map(_.name).toSet
     val requiredColumnsWithoutRowId = requiredColumns.filterNot(rowIdColumnSet.contains)
     val partitionColumnNames = hiveAcidMetadata.partitionSchema.fields.map(_.name)
     val partitionedColumnSet = partitionColumnNames.toSet
@@ -96,7 +96,7 @@ private[hiveacid] class TableReader(sparkSession: SparkSession,
       requiredNonPartitionedColumns,
       readConf)
 
-    val hiveAcidReaderOptions= HiveAcidReaderOptions.get(hiveAcidMetadata, readConf.includeRowIds)
+    val hiveAcidReaderOptions= HiveAcidReaderOptions.get(hiveAcidMetadata)
 
     val (partitions, partitionList) = HiveAcidReader.getPartitions(hiveAcidMetadata,
       readerOptions,

--- a/src/main/scala/com/qubole/spark/hiveacid/reader/hive/HiveAcidReaderOptions.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/reader/hive/HiveAcidReaderOptions.scala
@@ -24,16 +24,10 @@ import com.qubole.spark.hiveacid.hive.HiveAcidMetadata
 import org.apache.spark.sql.types.StructType
 
 private[reader] class HiveAcidReaderOptions(val tableDesc: TableDesc,
-                                            val rowIdSchema: Option[StructType],
                                             val isFullAcidTable: Boolean)
 
 private[reader] object HiveAcidReaderOptions {
-  def get(hiveAcidMetadata: HiveAcidMetadata, includeRowIds: Boolean): HiveAcidReaderOptions = {
-    val rowIdSchema = if (includeRowIds) {
-      Option(hiveAcidMetadata.rowIdSchema)
-    } else {
-      None
-    }
-    new HiveAcidReaderOptions(hiveAcidMetadata.tableDesc, rowIdSchema, hiveAcidMetadata.isFullAcidTable)
+  def get(hiveAcidMetadata: HiveAcidMetadata): HiveAcidReaderOptions = {
+    new HiveAcidReaderOptions(hiveAcidMetadata.tableDesc, hiveAcidMetadata.isFullAcidTable)
   }
 }


### PR DESCRIPTION
if we selected non-rowId columns from  DataFrame on ACID tables created  with includeRowIds, it would fail. Same if we ran count() on such Dataframes. That has been fixed now.

(cherry picked from commit 9aff6d4db4e42bdd1b5e05fe2db374d4d071e850) (SPAR-4432)