### PR TITLE
Issue#21 Add Partition Pruner as a fallback when HMS pruning fails

### DIFF
--- a/src/main/scala/com/qubole/spark/hiveacid/hive/HiveAcidMetadata.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/hive/HiveAcidMetadata.scala
@@ -123,17 +123,7 @@ class HiveAcidMetadata(sparkSession: SparkSession,
     val hive: Hive = Hive.get(hiveConf)
     val prunedPartitions = try {
       partitionFilters match {
-        case Some(filter) => try {
-          hive.getPartitionsByFilter(hTable, filter)
-        } catch {
-          // TODO: Enable pruning results returned by getting all Partitions
-          case ex: com.qubole.shaded.hadoop.hive.metastore.api.MetaException => {
-            logWarning("Caught Hive MetaException attempting to get partition metadata by " +
-            "filter from Hive. Falling back to fetching all partition metadata, which will " +
-              "degrade performance. Filter: " + filter, ex)
-            hive.getPartitions(hTable)
-          }
-        }
+        case Some(filter) => hive.getPartitionsByFilter(hTable, filter)
         case None => hive.getPartitions(hTable)
       }
     } finally {

--- a/src/main/scala/com/qubole/spark/hiveacid/hive/HiveConverter.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/hive/HiveConverter.scala
@@ -17,6 +17,7 @@
 
 package com.qubole.spark.hiveacid.hive
 
+import java.sql.{Date, Timestamp}
 import java.util.Locale
 
 import com.qubole.shaded.hadoop.hive.conf.HiveConf
@@ -93,6 +94,9 @@ private[hiveacid] object HiveConverter extends Logging {
     */
   private def compileValue(value: Any): Any = value match {
     case stringValue: String => s"'${escapeSql(stringValue)}'"
+    case timestampValue: Timestamp => "'" + timestampValue + "'"
+    case dateValue: Date => "'" + dateValue + "'"
+    case arrayValue: Array[Any] => arrayValue.map(compileValue).mkString(", ")
     case _ => value
   }
 

--- a/src/main/scala/com/qubole/spark/hiveacid/hive/HiveConverter.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/hive/HiveConverter.scala
@@ -111,8 +111,9 @@ private[hiveacid] object HiveConverter extends Logging {
     case GreaterThan(attr, value) => s"$attr > ${compileValue(value)}"
     case LessThanOrEqual(attr, value) => s"$attr <= ${compileValue(value)}"
     case GreaterThanOrEqual(attr, value) => s"$attr >= ${compileValue(value)}"
-    case IsNull(attr) => s"$attr = 'NULL'"
-    case IsNotNull(attr) => s"$attr != 'NULL'"
+    // These clauses throw in Hive MS when filtering the partitions
+    //case IsNull(attr) => s"$attr = 'NULL'"
+    //case IsNotNull(attr) => s"$attr != 'NULL'"
     case StringStartsWith(attr, value) => s"$attr LIKE '$value%'"
     case StringEndsWith(attr, value) => s"$attr LIKE '%$value'"
     case StringContains(attr, value) => s"$attr LIKE '%$value%'"

--- a/src/main/scala/com/qubole/spark/hiveacid/reader/ReaderOptions.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/reader/ReaderOptions.scala
@@ -33,4 +33,5 @@ private[hiveacid] class ReaderOptions(val hadoopConf: Configuration,
                                       val requiredAttributes: Seq[Attribute],
                                       val dataFilters: Array[Filter],
                                       val requiredNonPartitionedColumns: Array[String],
+                                      val sessionLocalTimeZone: String,
                                       val readConf: SparkAcidConf) extends Serializable

--- a/src/main/scala/com/qubole/spark/hiveacid/reader/TableReader.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/reader/TableReader.scala
@@ -94,6 +94,7 @@ private[hiveacid] class TableReader(sparkSession: SparkSession,
       requiredAttributes,
       dataFilters,
       requiredNonPartitionedColumns,
+      sparkSession.sessionState.conf.sessionLocalTimeZone,
       readConf)
 
     val hiveAcidReaderOptions= HiveAcidReaderOptions.get(hiveAcidMetadata)

--- a/src/main/scala/org/apache/spark/sql/hive/HiveAcidUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/hive/HiveAcidUtils.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Qubole, Inc.  All rights reserved.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.hive
+
+import scala.collection.JavaConverters._
+import com.qubole.spark.hiveacid.hive.HiveAcidMetadata
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTablePartition, CatalogUtils}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BoundReference, Expression, InterpretedPredicate, PrettyAttribute}
+
+object HiveAcidUtils {
+
+  /**
+    * This is adapted from [[org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.prunePartitionsByFilter]]
+    * Instead of [[org.apache.spark.sql.catalyst.catalog.CatalogTable]] this function will be using [[HiveAcidMetadata]]
+    * @param hiveAcidMetadata
+    * @param inputPartitions
+    * @param predicates
+    * @param defaultTimeZoneId
+    * @return
+    */
+  def prunePartitionsByFilter(
+                               hiveAcidMetadata: HiveAcidMetadata,
+                               inputPartitions: Seq[CatalogTablePartition],
+                               predicates: Option[Expression],
+                               defaultTimeZoneId: String): Seq[CatalogTablePartition] = {
+    if (predicates.isEmpty) {
+      inputPartitions
+    } else {
+      val partitionSchema = hiveAcidMetadata.partitionSchema
+      val partitionColumnNames = hiveAcidMetadata.partitionSchema.fieldNames.toSet
+
+      val nonPartitionPruningPredicates = predicates.filterNot {
+        _.references.map(_.name).toSet.subsetOf(partitionColumnNames)
+      }
+      if (nonPartitionPruningPredicates.nonEmpty) {
+        throw new AnalysisException("Expected only partition pruning predicates: " +
+          nonPartitionPruningPredicates)
+      }
+
+      val boundPredicate =
+        InterpretedPredicate.create(predicates.get.transform {
+          case att: Attribute =>
+            val index = partitionSchema.indexWhere(_.name == att.name)
+            BoundReference(index, partitionSchema(index).dataType, nullable = true)
+        })
+
+      inputPartitions.filter { p =>
+        boundPredicate.eval(p.toRow(partitionSchema, defaultTimeZoneId))
+      }
+    }
+  }
+
+  def convertToCatalogTablePartition(hp: com.qubole.shaded.hadoop.hive.ql.metadata.Partition): CatalogTablePartition = {
+    val apiPartition = hp.getTPartition
+    val properties: Map[String, String] = if (hp.getParameters != null) {
+      hp.getParameters.asScala.toMap
+    } else {
+      Map.empty
+    }
+    CatalogTablePartition(
+      spec = Option(hp.getSpec).map(_.asScala.toMap).getOrElse(Map.empty),
+      storage = CatalogStorageFormat(
+        locationUri = Option(CatalogUtils.stringToURI(apiPartition.getSd.getLocation)),
+        inputFormat = Option(apiPartition.getSd.getInputFormat),
+        outputFormat = Option(apiPartition.getSd.getOutputFormat),
+        serde = Option(apiPartition.getSd.getSerdeInfo.getSerializationLib),
+        compressed = apiPartition.getSd.isCompressed,
+        properties = Option(apiPartition.getSd.getSerdeInfo.getParameters)
+          .map(_.asScala.toMap).orNull),
+      createTime = apiPartition.getCreateTime.toLong * 1000,
+      lastAccessTime = apiPartition.getLastAccessTime.toLong * 1000,
+      parameters = properties,
+      stats = None) // TODO: need to implement readHiveStats
+  }
+}


### PR DESCRIPTION
When we pass few kind of predicates like `in` predicates to Hive Metastore Servie to fetch partitions it fails. As a fallback: 
1. all the partitions are fetched 
2. after fetching all partitions from Hive Metastore, they will be pruned. This will cause unneeded partitions are not processed.
Other small fix associated with Partition Pruning:
a. Don't allow predicates of form to be sent to HMS: `<partition_column> != null` `<partition_column> = null`