### PR TITLE
Issue #50  Use rowId with partitions for Merge Cardinality check

### DIFF
--- a/src/it/scala/com/qubole/spark/hiveacid/MergeSuite.scala
+++ b/src/it/scala/com/qubole/spark/hiveacid/MergeSuite.scala
@@ -107,7 +107,7 @@ class MergeSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAfterAll
     def getCreate(name: String) = s"create table $name (id int, " +
       "addr struct<AddressLine1:array<string>," +
       "City:array<string>,Country:array<string>," +
-      "StateProvince:array<string>,Zip:array<string>>) " +
+      "StateProvince:array<string>,Zip:array<string>>, prop map<int, string>) " +
       "stored as ORC tblproperties('transactional' = 'true')"
 
     val srcTblName = DEFAULT_DBNAME + ".srcTable"
@@ -117,10 +117,13 @@ class MergeSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAfterAll
     helper.hiveExecute(getCreate(srcTblName))
     helper.hiveExecute(getCreate(tgtTblName))
     helper.hiveExecute(s"insert into $tgtTblName values (1," +
-      s"named_struct('addressLine1', array('xyz', 'abc'), 'City', array('xyz', 'abc'), 'Country', array('xyz', 'abc'), 'StateProvince', array('xyz', 'abc'), 'Zip', array()))")
+      s"named_struct('addressLine1', array('xyz', 'abc'), 'City', array('xyz', 'abc'), 'Country', array('xyz', 'abc')," +
+      s" 'StateProvince', array('xyz', 'abc'), 'Zip', array()), map(1, 'test'))")
     helper.hiveExecute(s"insert into $srcTblName values (1," +
-      s"named_struct('addressLine1', array('u', 'abc'), 'City', array('xyz', 'abc'), 'Country', array('xyz', 'abc'), 'StateProvince', array('xyz', 'abc'), 'Zip', array()))," +
-      s"(2, named_struct('addressLine1', array('u', 'abc'), 'City', array('xyz', 'abc'), 'Country', array('xyz', 'abc'), 'StateProvince', array('xyz', 'abc'), 'Zip', array()))")
+      s"named_struct('addressLine1', array('u', 'abc'), 'City', array('xyz', 'abc'), 'Country', array('xyz', 'abc'), " +
+      s"'StateProvince', array('xyz', 'abc'), 'Zip', array()), map(1, 'test'))," +
+      s"(2, named_struct('addressLine1', array('u', 'abc'), 'City', array('xyz', 'abc'), 'Country', array('xyz', 'abc'), " +
+      s"'StateProvince', array('xyz', 'abc'), 'Zip', array()),map(1, 'test'))")
     val merge = s"""merge into $tgtTblName t using $srcTblName s on s.id=t.id
          | when matched  then update set addr=s.addr
          | when not matched then insert values(*)""".stripMargin


### PR DESCRIPTION
Merge Cardinality check ensures that 1 target row matches with only 1 source row.
After joining target and source tables (right outer join) to figure out the matched columns,
group by entire target columns were being done. Each group should have just 1 row else cardinality
check fails. Instead of using entire target columns we can use rowId + partition columns as rowIds
are unique for partition. Group by cannot be done on few data types like `map`, so this fix is required.

(cherry picked from commit 6bd81d66144d4f902cb13884063ca2516ca62687 (SPAR-4483))