### PR TITLE
Issue #59 Update on partition columns are disallowed

### DIFF
--- a/src/it/scala/com/qubole/spark/hiveacid/UpdateDeleteSuite.scala
+++ b/src/it/scala/com/qubole/spark/hiveacid/UpdateDeleteSuite.scala
@@ -143,4 +143,15 @@ class UpdateDeleteSuite extends FunSuite with BeforeAndAfterEach with BeforeAndA
       }
     }
   }
+
+  test("Test Update on Partition Columns is not allowed") {
+    val tableNameSpark = "tUpdateNeg"
+    val tableSpark = new Table(DEFAULT_DBNAME, tableNameSpark, cols,
+      Table.orcPartitionedFullACIDTable, true)
+    helper.recreate(tableSpark,false)
+    val thrown = intercept[AnalysisException] {
+      helper.sparkSQL(s"UPDATE ${DEFAULT_DBNAME}.${tableNameSpark} set ptnCol = 2 where intCol > 10")
+    }
+    assert(thrown.getMessage.contains("UPDATE on the partition columns are not allowed"))
+  }
 }

--- a/src/main/scala/com/qubole/spark/hiveacid/HiveAcidErrors.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/HiveAcidErrors.scala
@@ -104,6 +104,17 @@ object HiveAcidErrors {
       s"SET column ${formatColumn(col)} not found among columns: ${formatColumnList(colList)}.")
   }
 
+  def updateOnPartition(cols: Seq[String], table: String): Throwable = {
+    val message = if (cols.length == 1) {
+      s"SET column: ${cols.head} is partition column in table: ${table}"
+    } else {
+      s"SET columns: ${cols.mkString(",")} are partition columns in table: ${table}"
+    }
+    new AnalysisException(
+      s"UPDATE on the partition columns are not allowed. $message"
+    )
+  }
+
   def txnOutdated(txnId: Long, tableName: String): Throwable = {
     new TransactionInvalidException(
       s"Transaction is $txnId is no longer valid for table $tableName", txnId, tableName)

--- a/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxnManager.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxnManager.scala
@@ -327,7 +327,9 @@ private[hiveacid] class HiveAcidTxnManager(sparkSession: SparkSession) extends L
         }
         if (res.getState != LockState.ACQUIRED) {
           // Release lock in WAITING state
-          client.unlock(res.getLockid)
+          if (res.getState == LockState.WAITING) {
+            client.unlock(res.getLockid)
+          }
           throw HiveAcidErrors.couldNotAcquireLockException(state = res.getState.name())
         }
       } catch {


### PR DESCRIPTION
Earlier update on partition columns was happening leading to wrong results.
This has to be disallowed as Hive Writers don't expect it.