### PR TITLE
issue #54 Fix the Hearbeat Runner

### DIFF
--- a/src/it/scala/com/qubole/spark/hiveacid/TestHelper.scala
+++ b/src/it/scala/com/qubole/spark/hiveacid/TestHelper.scala
@@ -43,11 +43,17 @@ class TestHelper extends SQLImplicits {
   def init(isDebug: Boolean) {
     verbose = isDebug
     // Clients
-    spark = TestSparkSession.getSession
+    spark = getSparkSession()
     if (verbose) {
       log.setLevel(Level.DEBUG)
     }
     hiveClient = new TestHiveClient()
+  }
+
+  // this function can be overridden by the derived classes
+  // to create their own Spark Session for test
+  protected def getSparkSession(): SparkSession = {
+    TestSparkSession.getSession
   }
 
   def destroy(): Unit = {

--- a/src/main/scala/com/qubole/spark/hiveacid/HiveAcidTable.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/HiveAcidTable.scala
@@ -66,11 +66,13 @@ class HiveAcidTable(val sparkSession: SparkSession,
     curTxn match {
       case null =>
         // create local txn
+        logInfo("Creating new transaction")
         curTxn = HiveAcidTxn.createTransaction(sparkSession)
         curTxn.begin()
         isLocalTxn = true
+        logInfo(s"Transaction created: ${curTxn.txnId}")
       case txn =>
-        logDebug(s"Existing Transactions $txn")
+        logInfo(s"Using existing transaction:  ${curTxn.txnId}")
     }
   }
 
@@ -78,8 +80,10 @@ class HiveAcidTable(val sparkSession: SparkSession,
   // if locally started
   private def unsetOrEndTxn(abort: Boolean = false): Unit = {
     if (! isLocalTxn) {
+      logInfo(s"Not ending the transaction ${curTxn.txnId} as it's not Local")
       return
     }
+    logInfo(s"Ending Transaction ${curTxn.txnId} with abort flag: $abort")
     curTxn.end(abort)
     curTxn = null
     isLocalTxn = false

--- a/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxn.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxn.scala
@@ -105,6 +105,8 @@ class HiveAcidTxn(sparkSession: SparkSession) extends Logging {
       logError(s"Transaction already closed $this")
       throw HiveAcidErrors.txnAlreadyClosed(id)
     }
+    logInfo(s"Adding dynamic partition txnId: $id writeId: $writeId dbName: $dbName" +
+      s" tableName: $tableName partitions: ${partitions.mkString(",")}")
     HiveAcidTxn.txnManager.addDynamicPartitions(id, writeId, dbName,
       tableName, partitions, operationType)
   }

--- a/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxn.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxn.scala
@@ -105,7 +105,7 @@ class HiveAcidTxn(sparkSession: SparkSession) extends Logging {
       logError(s"Transaction already closed $this")
       throw HiveAcidErrors.txnAlreadyClosed(id)
     }
-    logInfo(s"Adding dynamic partition txnId: $id writeId: $writeId dbName: $dbName" +
+    logDebug(s"Adding dynamic partition txnId: $id writeId: $writeId dbName: $dbName" +
       s" tableName: $tableName partitions: ${partitions.mkString(",")}")
     HiveAcidTxn.txnManager.addDynamicPartitions(id, writeId, dbName,
       tableName, partitions, operationType)

--- a/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxnManager.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxnManager.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.{Executors, ScheduledExecutorService, ThreadFactory,
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.qubole.shaded.hadoop.hive.common.{ValidTxnList, ValidTxnWriteIdList, ValidWriteIdList}
-import com.qubole.shaded.hadoop.hive.metastore.api.{DataOperationType, LockRequest, LockResponse, LockState}
+import com.qubole.shaded.hadoop.hive.metastore.api.{DataOperationType, LockRequest, LockResponse, LockState, TxnInfo}
 import com.qubole.shaded.hadoop.hive.metastore.conf.MetastoreConf
 import com.qubole.shaded.hadoop.hive.metastore.txn.TxnUtils
 import com.qubole.shaded.hadoop.hive.metastore.{HiveMetaStoreClient, LockComponentBuilder, LockRequestBuilder}
@@ -46,7 +46,7 @@ private[hiveacid] class HiveAcidTxnManager(sparkSession: SparkSession) extends L
   private val hiveConf = HiveConverter.getHiveConf(sparkSession.sparkContext)
 
   private val heartbeatInterval = MetastoreConf.getTimeVar(hiveConf,
-    MetastoreConf.ConfVars.TXN_TIMEOUT, TimeUnit.MILLISECONDS) / 2
+    MetastoreConf.ConfVars.TXN_TIMEOUT, TimeUnit.MILLISECONDS) / 3
 
   private lazy val client: HiveMetaStoreClient = new HiveMetaStoreClient(
     hiveConf, null, false)
@@ -67,7 +67,7 @@ private[hiveacid] class HiveAcidTxnManager(sparkSession: SparkSession) extends L
 
   private val user: String = sparkSession.sparkContext.sparkUser
 
-  private val shutdownInitiated: AtomicBoolean = new AtomicBoolean(true)
+  private val shutdownInitiated: AtomicBoolean = new AtomicBoolean(false)
 
   /**
     * Register transactions with Hive Metastore and tracks it under HiveAcidTxnManager.activeTxns
@@ -213,6 +213,10 @@ private[hiveacid] class HiveAcidTxnManager(sparkSession: SparkSession) extends L
       case _ =>
         throw HiveAcidErrors.invalidOperationType(operationType.toString)
     }
+  }
+
+  def showOpenTrans(): Seq[TxnInfo] = {
+    client.showTxns().getOpen_txns.toSeq
   }
 
   /**

--- a/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxnManager.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxnManager.scala
@@ -95,7 +95,7 @@ private[hiveacid] class HiveAcidTxnManager(sparkSession: SparkSession) extends L
       // NB: Remove it from tracking before making HMS call
       // which can potentially fail.
       HiveAcidTxnManager.activeTxns.remove(txnId)
-      logDebug(s"Removing txnId: $txnId from tracker")
+      logInfo(s"Removing txnId: $txnId from tracker")
       if (abort) {
         client.abortTxns(scala.collection.JavaConversions.seqAsJavaList(Seq(txnId)))
       } else {
@@ -361,7 +361,7 @@ private[hiveacid] class HiveAcidTxnManager(sparkSession: SparkSession) extends L
           logError(s"Heartbeat failure for transaction id: ${txn.txnId} : ${resp.toString}." +
             s"Aborting...")
         } else {
-          logDebug(s"Heartbeat sent for txnId: ${txn.txnId}")
+          logInfo(s"Heartbeat sent for txnId: ${txn.txnId}")
         }
       } catch {
         // No action required because if heartbeat doesn't go for some time, transaction will be


### PR DESCRIPTION
HeartBeat runner runs periodically to ensure open transactions and locks are alive. This was not running as shutDown flag was turned true by default. Fix includes Docker Test for the same.

docker Tests:
[info] LockSuite:
[info] - test lock wait timeout exception
[info] - test locks within same transaction is allowed
[info] - test READ after UPDATE/DELETE is allowed
[info] - test DELETE/READ after INSERT OVERWRITE is not allowed
[info] - test INSERT_OVERWRITE and DELETE/UPDATE/READ on different partition is allowed
[info] - test HeartBeatRunner is running
[info] ScalaTest
[info] Run completed in 41 seconds, 660 milliseconds.
[info] Total number of tests run: 6
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 6, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 6, Failed 0, Errors 0, Passed 6
[success] Total time: 79 s, completed Jun 16, 2020 10:44:11 AM
20/06/16 10:44:11 INFO ShutdownHookManager: Shutdown hook called
20/06/16 10:44:11 INFO ShutdownHookManager: Deleting directory /private/var/folders/tp/5zf7pt797979fc9whkz636kn_rqxry/T/spark-a7530895-d41e-46b3-8348-136daeb3c519