### PR TITLE
Issue #68 Avoid updating Partition columns via Merge

### DIFF
--- a/src/it/scala/com/qubole/spark/hiveacid/MergeSuite.scala
+++ b/src/it/scala/com/qubole/spark/hiveacid/MergeSuite.scala
@@ -150,6 +150,18 @@ class MergeSuite extends FunSuite with BeforeAndAfterEach with BeforeAndAfterAll
       "Please check MERGE match condition and try again"))
   }
 
+  test("Merge Test on Partitioned ORC with Update on Columns") {
+    val tableNameSpark = "tSparkUpdatePartitionColumned"
+    val tableSpark = new Table(DEFAULT_DBNAME, tableNameSpark, cols,
+      Table.orcPartitionedFullACIDTable, true)
+    helper.recreate(tableSpark, false)
+    val thrown = intercept[com.qubole.spark.hiveacid.AnalysisException] {
+      helper.sparkSQL(tableSpark.mergeCommand(sourcePartitioned.hiveTname, "t.key >= 11 and t.key < 17",
+        "t.key > 16", "*", "intCol=s.intCol * 10, ptnCol=s.ptnCol"))
+    }
+    assert(thrown.getMessage().contains("UPDATE on the partition columns are not allowed"))
+  }
+
   // Merge test for full acid tables
   def mergeTestWithJustInsert(tType: String, isPartitioned: Boolean): Unit = {
     val tableNameSpark = if (isPartitioned) {

--- a/src/it/scala/com/qubole/spark/hiveacid/Table.scala
+++ b/src/it/scala/com/qubole/spark/hiveacid/Table.scala
@@ -154,9 +154,10 @@ class Table (
 
   def majorCompaction = s"ALTER TABLE ${hiveTname} COMPACT 'major'"
 
-  def mergeCommand(sourceTable: String, updateCond: String, deleteCond: String, insertCols: String): String =
+  def mergeCommand(sourceTable: String, updateCond: String, deleteCond: String,
+                   insertCols: String, updateSet: String = "intCol=s.intCol * 10"): String =
     s" merge into $hiveTname t using $sourceTable s on s.key=t.key " +
-      s" when matched and $updateCond then update set intCol=s.intCol * 10 " +
+      s" when matched and $updateCond then update set $updateSet " +
       s" when matched and $deleteCond then delete " +
       s" when not matched then insert values($insertCols)"
 

--- a/src/main/scala/com/qubole/spark/hiveacid/HiveAcidTable.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/HiveAcidTable.scala
@@ -22,7 +22,7 @@ import com.qubole.spark.hiveacid.datasource.HiveAcidDataSource
 import com.qubole.spark.hiveacid.merge.{MergeWhenClause, MergeWhenNotInsert}
 import com.qubole.spark.hiveacid.rdd.EmptyRDD
 import com.qubole.spark.hiveacid.transaction._
-import org.apache.spark.annotation.InterfaceStability.{Evolving}
+import org.apache.spark.annotation.InterfaceStability.Evolving
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, _}
@@ -206,6 +206,10 @@ class HiveAcidTable(val sparkSession: SparkSession,
 
   def isBucketed: Boolean = {
     hiveAcidMetadata.isBucketed
+  }
+
+  def isPartitioned: Boolean = {
+    hiveAcidMetadata.isPartitioned
   }
 }
 

--- a/src/main/scala/com/qubole/spark/hiveacid/datasource/HiveAcidRelation.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/datasource/HiveAcidRelation.scala
@@ -99,6 +99,10 @@ case class HiveAcidRelation(sparkSession: SparkSession,
       notMatched, sourceAlias, targetAlias)
   }
 
+  def getHiveAcidTable(): HiveAcidTable = {
+    hiveAcidTable
+  }
+
   // FIXME: should it be true / false. Recommendation seems to
   //  be to leave it as true
   override val needConversion: Boolean = false

--- a/src/main/scala/com/qubole/spark/hiveacid/merge/MergeImpl.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/merge/MergeImpl.scala
@@ -21,7 +21,7 @@ package com.qubole.spark.hiveacid.merge
 
 import com.qubole.spark.hiveacid.hive.HiveAcidMetadata
 import com.qubole.spark.hiveacid.transaction.HiveAcidTxn
-import com.qubole.spark.hiveacid.{AcidOperationDelegate, HiveAcidErrors, HiveAcidOperation, HiveAcidTable}
+import com.qubole.spark.hiveacid.{AcidOperationDelegate, HiveAcidErrors, HiveAcidOperation}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, Literal, Not}
 import org.apache.spark.sql.{Column, DataFrame, SparkSession, SqlUtils, functions}
 import org.apache.spark.sql.catalyst.parser.plans.logical.MergePlan


### PR DESCRIPTION
Merge Update is not allowed to change the partition columns.

(cherry picked from commit 81646cac87de9ca2e63587096d41ddde6e134676)