### PR TITLE
fix:usr:SPAR-4651 Don't allocate writeIds for Read transactions

### DIFF
--- a/src/main/scala/com/qubole/spark/hiveacid/reader/TableReader.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/reader/TableReader.scala
@@ -109,20 +109,21 @@ private[hiveacid] class TableReader(sparkSession: SparkSession,
     curTxn.acquireLocks(hiveAcidMetadata, HiveAcidOperation.READ, partitionList, readConf)
 
     // Create Snapshot !!!
-    val curSnapshot = HiveAcidTxn.createSnapshot(curTxn, hiveAcidMetadata)
+    //val curSnapshot = HiveAcidTxn.createSnapshot(curTxn, hiveAcidMetadata)
+
+    val validWriteIds = HiveAcidTxn.getValidWriteIds(curTxn, hiveAcidMetadata)
 
     val reader = new HiveAcidReader(
       sparkSession,
       readerOptions,
       hiveAcidReaderOptions,
-      curSnapshot.validWriteIdList)
+      validWriteIds)
 
     val rdd = if (hiveAcidMetadata.isPartitioned) {
       reader.makeRDDForPartitionedTable(hiveAcidMetadata, partitions)
     } else {
       reader.makeRDDForTable(hiveAcidMetadata)
     }
-
 
     rdd.asInstanceOf[RDD[Row]]
   }

--- a/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxn.scala
+++ b/src/main/scala/com/qubole/spark/hiveacid/transaction/HiveAcidTxn.scala
@@ -122,12 +122,17 @@ object HiveAcidTxn extends Logging {
   private[hiveacid] def createSnapshot(txn: HiveAcidTxn, hiveAcidMetadata: HiveAcidMetadata): HiveAcidTableSnapshot = {
     val currentWriteId = txnManager.getCurrentWriteId(txn.txnId,
       hiveAcidMetadata.dbName, hiveAcidMetadata.tableName)
-    val validWriteIdList = if (txn.txnId == - 1) {
-      throw HiveAcidErrors.tableWriteIdRequestedBeforeTxnStart (hiveAcidMetadata.fullyQualifiedName)
-    } else {
-      txnManager.getValidWriteIds(txn.txnId, txn.validTxnList ,hiveAcidMetadata.fullyQualifiedName)
-    }
+    val validWriteIdList: ValidWriteIdList = getValidWriteIds(txn, hiveAcidMetadata)
     HiveAcidTableSnapshot(validWriteIdList, currentWriteId)
+  }
+
+  private[hiveacid] def getValidWriteIds(txn: HiveAcidTxn, hiveAcidMetadata: HiveAcidMetadata) = {
+    val validWriteIdList = if (txn.txnId == -1) {
+      throw HiveAcidErrors.tableWriteIdRequestedBeforeTxnStart(hiveAcidMetadata.fullyQualifiedName)
+    } else {
+      txnManager.getValidWriteIds(txn.txnId, txn.validTxnList, hiveAcidMetadata.fullyQualifiedName)
+    }
+    validWriteIdList
   }
 
   // Txn manager is connection to HMS. Use single instance of it


### PR DESCRIPTION
For read transactions, we are allocating new write Ids which should not be done. It ideally should only be allocated for Write transaction. It's not a functional issue/bug but not required to be done. This change will ensure economical usage of writeIds.